### PR TITLE
Add additional stats to benchmark results

### DIFF
--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -19,6 +19,7 @@ package benchmark
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/awslabs/soci-snapshotter/benchmark/framework"
 	"github.com/containerd/containerd"
@@ -107,10 +108,13 @@ func SociFullRun(
 	defer sociProcess.StopProcess()
 	sociContainerdProc := SociContainerdProcess{containerdProcess}
 	b.ResetTimer()
+	pullStart := time.Now()
 	log.G(ctx).WithField("benchmark", "Test").WithField("event", "Start").Infof("Start Test")
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Start").Infof("Start Pull Image")
 	image, err := sociContainerdProc.SociRPullImageFromRegistry(ctx, imageRef, indexDigest)
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Stop").Infof("Stop Pull Image")
+	pullDuration := time.Since(pullStart)
+	b.ReportMetric(float64(pullDuration.Milliseconds()), "pullDuration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -129,8 +133,11 @@ func SociFullRun(
 	}
 	defer cleanupTask()
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Start").Infof("Start Run Task")
+	runTask1Start := time.Now()
 	cleanupRun, err := sociContainerdProc.RunContainerTaskForReadyLine(ctx, taskDetails, readyLine)
+	runTask1Duration := time.Since(runTask1Start)
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Stop").Infof("Stop Run Task")
+	b.ReportMetric(float64(runTask1Duration.Milliseconds()), "runTask1Duration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -146,8 +153,11 @@ func SociFullRun(
 	}
 	defer cleanupTaskSecondRun()
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Start").Infof("Start Run Task Twice")
+	runTask2Start := time.Now()
 	cleanupRunSecond, err := sociContainerdProc.RunContainerTaskForReadyLine(ctx, taskDetailsSecondRun, readyLine)
+	runTask2Duration := time.Since(runTask2Start)
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Stop").Infof("Stop Run Task Twice")
+	b.ReportMetric(float64(runTask2Duration.Milliseconds()), "runTask2Duration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -173,8 +183,11 @@ func OverlayFSFullRun(
 	b.ResetTimer()
 	log.G(ctx).WithField("benchmark", "Test").WithField("event", "Start").Infof("Start Test")
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Start").Infof("Start Pull Image")
+	pullStart := time.Now()
 	image, err := containerdProcess.PullImageFromRegistry(ctx, imageRef, platform)
+	pullDuration := time.Since(pullStart)
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Stop").Infof("Stop Pull Image")
+	b.ReportMetric(float64(pullDuration.Milliseconds()), "pullDuration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -185,8 +198,11 @@ func OverlayFSFullRun(
 		b.Fatalf("%s", err)
 	}
 	log.G(ctx).WithField("benchmark", "CreateContainer").WithField("event", "Start").Infof("Start Create Container")
+	createContainerStart := time.Now()
 	container, cleanupContainer, err := containerdProcess.CreateContainer(ctx, image)
+	createContainerDuration := time.Since(createContainerStart)
 	log.G(ctx).WithField("benchmark", "CreateContainer").WithField("event", "Stop").Infof("Stop Create Container")
+	b.ReportMetric(float64(createContainerDuration.Milliseconds()), "createContainerDuration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -199,8 +215,11 @@ func OverlayFSFullRun(
 	}
 	defer cleanupTask()
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Start").Infof("Start Run Task")
+	runTask1Start := time.Now()
 	cleanupRun, err := containerdProcess.RunContainerTaskForReadyLine(ctx, taskDetails, readyLine)
+	runTask1Duration := time.Since(runTask1Start)
 	log.G(ctx).WithField("benchmark", "RunTask").WithField("event", "Stop").Infof("Stop Run Task")
+	b.ReportMetric(float64(runTask1Duration.Milliseconds()), "runTask1Duration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}
@@ -216,8 +235,11 @@ func OverlayFSFullRun(
 	}
 	defer cleanupTaskSecondRun()
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Start").Infof("Start Run Task Twice")
+	runTask2Start := time.Now()
 	cleanupRunSecond, err := containerdProcess.RunContainerTaskForReadyLine(ctx, taskDetailsSecondRun, readyLine)
+	runTask2Duration := time.Since(runTask2Start)
 	log.G(ctx).WithField("benchmark", "RunTaskTwice").WithField("event", "Stop").Infof("Stop Run Task Twice")
+	b.ReportMetric(float64(runTask2Duration.Milliseconds()), "runTask2Duration")
 	if err != nil {
 		b.Fatalf("%s", err)
 	}

--- a/benchmark/framework/framework.go
+++ b/benchmark/framework/framework.go
@@ -41,22 +41,29 @@ type BenchmarkFramework struct {
 	Drivers   []BenchmarkTestDriver `json:"benchmarkTests"`
 }
 
+type BenchmarkTestStats struct {
+	BenchmarkTimes []float64 `json:"BenchmarkTimes"`
+	StdDev         float64   `json:"stdDev"`
+	Mean           float64   `json:"mean"`
+	Min            float64   `json:"min"`
+	Pct25          float64   `json:"pct25"`
+	Pct50          float64   `json:"pct50"`
+	Pct75          float64   `json:"pct75"`
+	Pct90          float64   `json:"pct90"`
+	Max            float64   `json:"max"`
+}
+
 type BenchmarkTestDriver struct {
-	TestName       string           `json:"testName"`
-	NumberOfTests  int              `json:"numberOfTests"`
-	BeforeFunction func()           `json:"-"`
-	TestFunction   func(*testing.B) `json:"-"`
-	AfterFunction  func() error     `json:"-"`
-	TestsRun       int              `json:"-"`
-	TestTimes      []float64        `json:"testTimes"`
-	StdDev         float64          `json:"stdDev"`
-	Mean           float64          `json:"mean"`
-	Min            float64          `json:"min"`
-	Pct25          float64          `json:"pct25"`
-	Pct50          float64          `json:"pct50"`
-	Pct75          float64          `json:"pct75"`
-	Pct90          float64          `json:"pct90"`
-	Max            float64          `json:"max"`
+	TestName       string             `json:"testName"`
+	NumberOfTests  int                `json:"numberOfTests"`
+	BeforeFunction func()             `json:"-"`
+	TestFunction   func(*testing.B)   `json:"-"`
+	AfterFunction  func() error       `json:"-"`
+	TestsRun       int                `json:"-"`
+	TestStats      BenchmarkTestStats `json:"testStats"`
+	PullStats      BenchmarkTestStats `json:"pullStats"`
+	RunTask1Stats  BenchmarkTestStats `json:"runTask1Stats"`
+	RunTask2Stats  BenchmarkTestStats `json:"runTaskStats_WithoutOverhead"`
 }
 
 func (frame *BenchmarkFramework) Run(ctx context.Context) {
@@ -73,7 +80,10 @@ func (frame *BenchmarkFramework) Run(ctx context.Context) {
 			log.G(ctx).WithField("test_name", testDriver.TestName).Infof("TestStart for " + testDriver.TestName + "_" + strconv.Itoa(j+1))
 			fmt.Printf("Running test %d of %d\n", j+1, testDriver.NumberOfTests)
 			res := testing.Benchmark(testDriver.TestFunction)
-			testDriver.TestTimes = append(testDriver.TestTimes, res.T.Seconds())
+			testDriver.TestStats.BenchmarkTimes = append(testDriver.TestStats.BenchmarkTimes, res.T.Seconds())
+			testDriver.PullStats.BenchmarkTimes = append(testDriver.PullStats.BenchmarkTimes, res.Extra["pullDuration"]/1000)
+			testDriver.RunTask1Stats.BenchmarkTimes = append(testDriver.RunTask1Stats.BenchmarkTimes, res.Extra["runTask1Duration"]/1000)
+			testDriver.RunTask2Stats.BenchmarkTimes = append(testDriver.RunTask2Stats.BenchmarkTimes, res.Extra["runTask2Duration"]/1000)
 		}
 		testDriver.calculateStats()
 		if testDriver.AfterFunction != nil {
@@ -81,7 +91,6 @@ func (frame *BenchmarkFramework) Run(ctx context.Context) {
 			if err != nil {
 				fmt.Printf("After function error: %v\n", err)
 			}
-
 		}
 	}
 
@@ -102,44 +111,167 @@ func (frame *BenchmarkFramework) Run(ctx context.Context) {
 
 func (driver *BenchmarkTestDriver) calculateStats() {
 	var err error
-	driver.StdDev, err = stats.StandardDeviation(driver.TestTimes)
+	driver.TestStats.StdDev, err = stats.StandardDeviation(driver.TestStats.BenchmarkTimes)
 	if err != nil {
 		fmt.Printf("Error Calculating Std Dev: %v\n", err)
-		driver.StdDev = -1
+		driver.TestStats.StdDev = -1
 	}
-	driver.Mean, err = stats.Mean(driver.TestTimes)
+	driver.TestStats.Mean, err = stats.Mean(driver.TestStats.BenchmarkTimes)
 	if err != nil {
 		fmt.Printf("Error Calculating Mean: %v\n", err)
-		driver.Mean = -1
+		driver.TestStats.Mean = -1
 	}
-	driver.Min, err = stats.Min(driver.TestTimes)
+	driver.TestStats.Min, err = stats.Min(driver.TestStats.BenchmarkTimes)
 	if err != nil {
 		fmt.Printf("Error Calculating Min: %v\n", err)
-		driver.Min = -1
+		driver.TestStats.Min = -1
 	}
-	driver.Pct25, err = stats.Percentile(driver.TestTimes, 25)
+	driver.TestStats.Pct25, err = stats.Percentile(driver.TestStats.BenchmarkTimes, 25)
 	if err != nil {
 		fmt.Printf("Error Calculating 25th Pct: %v\n", err)
-		driver.Pct25 = -1
+		driver.TestStats.Pct25 = -1
 	}
-	driver.Pct50, err = stats.Percentile(driver.TestTimes, 50)
+	driver.TestStats.Pct50, err = stats.Percentile(driver.TestStats.BenchmarkTimes, 50)
 	if err != nil {
 		fmt.Printf("Error Calculating 50th Pct: %v\n", err)
-		driver.Pct50 = -1
+		driver.TestStats.Pct50 = -1
 	}
-	driver.Pct75, err = stats.Percentile(driver.TestTimes, 75)
+	driver.TestStats.Pct75, err = stats.Percentile(driver.TestStats.BenchmarkTimes, 75)
 	if err != nil {
 		fmt.Printf("Error Calculating 75th Pct: %v\n", err)
-		driver.Pct75 = -1
+		driver.TestStats.Pct75 = -1
 	}
-	driver.Pct90, err = stats.Percentile(driver.TestTimes, 90)
+	driver.TestStats.Pct90, err = stats.Percentile(driver.TestStats.BenchmarkTimes, 90)
 	if err != nil {
 		fmt.Printf("Error Calculating 90th Pct: %v\n", err)
-		driver.Pct90 = -1
+		driver.TestStats.Pct90 = -1
 	}
-	driver.Max, err = stats.Max(driver.TestTimes)
+	driver.TestStats.Max, err = stats.Max(driver.TestStats.BenchmarkTimes)
 	if err != nil {
 		fmt.Printf("Error Calculating Max: %v\n", err)
-		driver.Max = -1
+		driver.TestStats.Max = -1
+	}
+
+	driver.PullStats.StdDev, err = stats.StandardDeviation(driver.PullStats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("PullStats: Error Calculating Std Dev: %v\n", err)
+		driver.PullStats.StdDev = -1
+	}
+	driver.PullStats.Mean, err = stats.Mean(driver.PullStats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("PullStats: Error Calculating Mean: %v\n", err)
+		driver.PullStats.Mean = -1
+	}
+	driver.PullStats.Min, err = stats.Min(driver.PullStats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("PullStats: Error Calculating Min: %v\n", err)
+		driver.PullStats.Min = -1
+	}
+	driver.PullStats.Pct25, err = stats.Percentile(driver.PullStats.BenchmarkTimes, 25)
+	if err != nil {
+		fmt.Printf("PullStats: Error Calculating 25th Pct: %v\n", err)
+		driver.PullStats.Pct25 = -1
+	}
+	driver.PullStats.Pct50, err = stats.Percentile(driver.PullStats.BenchmarkTimes, 50)
+	if err != nil {
+		fmt.Printf("PullStats: Error Calculating 50th Pct: %v\n", err)
+		driver.PullStats.Pct50 = -1
+	}
+	driver.PullStats.Pct75, err = stats.Percentile(driver.PullStats.BenchmarkTimes, 75)
+	if err != nil {
+		fmt.Printf("PullStats: Error Calculating 75th Pct: %v\n", err)
+		driver.PullStats.Pct75 = -1
+	}
+	driver.PullStats.Pct90, err = stats.Percentile(driver.PullStats.BenchmarkTimes, 90)
+	if err != nil {
+		fmt.Printf("PullStats: Error Calculating 90th Pct: %v\n", err)
+		driver.PullStats.Pct90 = -1
+	}
+	driver.PullStats.Max, err = stats.Max(driver.PullStats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("PullStats: Error Calculating Max: %v\n", err)
+		driver.PullStats.Max = -1
+	}
+
+	driver.RunTask1Stats.StdDev, err = stats.StandardDeviation(driver.RunTask1Stats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("RunTask1Stats: Error Calculating Std Dev: %v\n", err)
+		driver.RunTask1Stats.StdDev = -1
+	}
+	driver.RunTask1Stats.Mean, err = stats.Mean(driver.RunTask1Stats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("RunTask1Stats: Error Calculating Mean: %v\n", err)
+		driver.RunTask1Stats.Mean = -1
+	}
+	driver.RunTask1Stats.Min, err = stats.Min(driver.RunTask1Stats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("RunTask1Stats: Error Calculating Min: %v\n", err)
+		driver.RunTask1Stats.Min = -1
+	}
+	driver.RunTask1Stats.Pct25, err = stats.Percentile(driver.RunTask1Stats.BenchmarkTimes, 25)
+	if err != nil {
+		fmt.Printf("RunTask1Stats: Error Calculating 25th Pct: %v\n", err)
+		driver.RunTask1Stats.Pct25 = -1
+	}
+	driver.RunTask1Stats.Pct50, err = stats.Percentile(driver.RunTask1Stats.BenchmarkTimes, 50)
+	if err != nil {
+		fmt.Printf("RunTask1Stats: Error Calculating 50th Pct: %v\n", err)
+		driver.RunTask1Stats.Pct50 = -1
+	}
+	driver.RunTask1Stats.Pct75, err = stats.Percentile(driver.RunTask1Stats.BenchmarkTimes, 75)
+	if err != nil {
+		fmt.Printf("RunTask1Stats: Error Calculating 75th Pct: %v\n", err)
+		driver.RunTask1Stats.Pct75 = -1
+	}
+	driver.RunTask1Stats.Pct90, err = stats.Percentile(driver.RunTask1Stats.BenchmarkTimes, 90)
+	if err != nil {
+		fmt.Printf("RunTask1Stats: Error Calculating 90th Pct: %v\n", err)
+		driver.RunTask1Stats.Pct90 = -1
+	}
+	driver.RunTask1Stats.Max, err = stats.Max(driver.RunTask1Stats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("RunTask1Stats: Error Calculating Max: %v\n", err)
+		driver.RunTask1Stats.Max = -1
+	}
+
+	driver.RunTask2Stats.StdDev, err = stats.StandardDeviation(driver.RunTask2Stats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("RunTask2Stats: Error Calculating Std Dev: %v\n", err)
+		driver.RunTask2Stats.StdDev = -1
+	}
+	driver.RunTask2Stats.Mean, err = stats.Mean(driver.RunTask2Stats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("RunTask2Stats: Error Calculating Mean: %v\n", err)
+		driver.RunTask2Stats.Mean = -1
+	}
+	driver.RunTask2Stats.Min, err = stats.Min(driver.RunTask2Stats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("RunTask2Stats: Error Calculating Min: %v\n", err)
+		driver.RunTask2Stats.Min = -1
+	}
+	driver.RunTask2Stats.Pct25, err = stats.Percentile(driver.RunTask2Stats.BenchmarkTimes, 25)
+	if err != nil {
+		fmt.Printf("RunTask2Stats: Error Calculating 25th Pct: %v\n", err)
+		driver.RunTask2Stats.Pct25 = -1
+	}
+	driver.RunTask2Stats.Pct50, err = stats.Percentile(driver.RunTask2Stats.BenchmarkTimes, 50)
+	if err != nil {
+		fmt.Printf("RunTask2Stats: Error Calculating 50th Pct: %v\n", err)
+		driver.RunTask2Stats.Pct50 = -1
+	}
+	driver.RunTask2Stats.Pct75, err = stats.Percentile(driver.RunTask2Stats.BenchmarkTimes, 75)
+	if err != nil {
+		fmt.Printf("RunTask2Stats: Error Calculating 75th Pct: %v\n", err)
+		driver.RunTask2Stats.Pct75 = -1
+	}
+	driver.RunTask2Stats.Pct90, err = stats.Percentile(driver.RunTask2Stats.BenchmarkTimes, 90)
+	if err != nil {
+		fmt.Printf("RunTask2Stats: Error Calculating 90th Pct: %v\n", err)
+		driver.RunTask2Stats.Pct90 = -1
+	}
+	driver.RunTask2Stats.Max, err = stats.Max(driver.RunTask2Stats.BenchmarkTimes)
+	if err != nil {
+		fmt.Printf("RunTask2Stats: Error Calculating Max: %v\n", err)
+		driver.RunTask2Stats.Max = -1
 	}
 }


### PR DESCRIPTION
This commit adds additional details like standard deviation,mean,p90 etc.. for individual events - 'Pull','Run Task 1' and 'Run Task 2(Running task without FUSE overhead)'

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
