### PR TITLE
Add shell script for benchmark visualization

### DIFF
--- a/.github/workflows/benchmark_regression_check.yml
+++ b/.github/workflows/benchmark_regression_check.yml
@@ -1,0 +1,52 @@
+name: Regression test
+
+on:
+  pull_request:
+    branches:
+      - main
+env:
+  Sha: ${{ github.event.pull_request.head.sha }}
+      
+
+jobs:
+  benchmark:
+    name: Run Benchmarks on PR
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: true
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.18.10'
+      - run: make
+      # - name: Run benchmark
+      #   run: make benchmarks-perf-test
+      # - run: cd benchmark/performanceTest && cat output/results.json
+  update-benchmark-result:
+    name: Update latest benchmark result
+    needs: benchmark
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update benchmark result
+        uses: actions/upload-artifact@v3
+        with:
+          name: benchmark-result_${{ env.Sha }}
+          path: results.json
+  fetch_previous_json_files:
+    runs-on: ubuntu-latest
+    needs: update-benchmark-result
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download previous artifact
+        id: download-artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: benchmark-result_${{ env.Sha }}
+          # github_token: ${{ secrets.GITHUB_TOKEN }}
+          # repo: ${{ github.repository }}
+          # path: ${{ github.workspace }}
+          # search_artifacts: true
+        

--- a/.github/workflows/benchmark_visualization.yml
+++ b/.github/workflows/benchmark_visualization.yml
@@ -38,7 +38,7 @@ jobs:
         - uses: actions/checkout@v3
         - uses: actions/upload-artifact@v3
           with:
-            name: benchmark-result
+            name: benchmark-result_${{ github.sha }}
             path: ${{github.workspace}}/results.json
 
   # push-benchmark-result-gh-pages:


### PR DESCRIPTION
This commit adds a visualization_data_converter shell script that accepts a results json file and converts it to a benchmark result compatible format for the visualization tooland this commits also adds 'benchmark_visualization' workflow which calls the shell script on every code merge and updates the data file in the gh-pages branch.

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
