### PR TITLE
Add workflows to run regression checks

### DIFF
--- a/.github/workflows/benchmark_regression_test.yml
+++ b/.github/workflows/benchmark_regression_test.yml
@@ -1,0 +1,77 @@
+name: Benchmark Regression Check
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**.go'
+      - 'go.*'
+      - 'cmd/go.*'
+      - 'Makefile'
+      - 'Dockerfile'
+      - 'integration/**'
+      - 'scripts/**'
+            
+jobs:
+  benchmark:
+    name: Performance regression check
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.18.10'
+      - run: make
+      # - name: Run benchmark
+      #   run: make benchmarks-perf-test
+  
+  fetch-previous-results_and_compare:
+    name: Fetch results
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.18.10'
+      - run: make
+      - name: Download artifact
+        id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          name: benchmark-result-artifact
+          name_is_regexp: true
+          path: ${{ github.workspace }}
+          repo: ${{ github.repository }}
+          check_artifacts: false
+          search_artifacts: true
+          skip_unpack: false
+          if_no_artifact_found: fail
+          workflow: benchmark_visualization.yml
+      # - name: Run Compare and handle result
+      #   id: run-compare
+      #   run: |
+      #       sudo chmod +x ${{ github.workspace }}/scripts/check_regression.sh
+      #       if sudo ${{ github.workspace }}/scripts/check_regression.sh ${{ github.workspace }}/benchmark-result.json ${{ github.workspace }}/benchmark-result-current.json; then
+      #         echo "Comparison successful. All P90 values are within the acceptable range."
+      #       else
+      #         echo "Comparison failed. Current P90 values exceed 110% of the corresponding past values."
+      #         echo "Adding a comment to the Pull Request."
+      #         echo "::set-output name=regression-detected::true"
+      #         echo "regression-detected=true" >> "$GITHUB_ENV"
+      #       fi
+        
+      # - name: Comment on PR if regression detected
+      #   if: steps.run-compare.outputs.regression-detected == 'true'
+      #   uses: actions/github-script@v6
+      #   with:
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     script: |
+      #       const comment = `
+      #         :warning: **Regression Detected** :warning:
+
+      #         The benchmark comparison indicates that there has been a performance regression.
+      #         Please investigate and address the issue.
+      #       `;
+
+      #       core.setFailed(comment);


### PR DESCRIPTION
This commit adds two workflows benchmark_visualization and benchmark_regression_check
benchmark_visualization: Runs the benchmark targets on merge and uploads the results as an artifact
benchmark_regression_check: Runs the benchmark targets and compares the result with the previously uploaded artifact using the comparison script and checks for regression.

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
