### PR TITLE
Add timeout of 10 secs

### DIFF
--- a/benchmark/framework/containerd_utils.go
+++ b/benchmark/framework/containerd_utils.go
@@ -209,6 +209,8 @@ func (proc *ContainerdProcess) RunContainerTaskForReadyLine(
 	stdoutScanner := bufio.NewScanner(taskDetails.stdoutReader)
 	stderrScanner := bufio.NewScanner(taskDetails.stderrReader)
 
+	time.Sleep(10 * time.Second)
+
 	exitStatusC, err := taskDetails.task.Wait(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit adds 10 secs to the RunContainerTaskForReadyLine function

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
