### PR TITLE
Add 60 secs delay to the benchmark tests

### DIFF
--- a/benchmark/benchmarkTests.go
+++ b/benchmark/benchmarkTests.go
@@ -109,6 +109,7 @@ func SociFullRun(
 	sociContainerdProc := SociContainerdProcess{containerdProcess}
 	b.ResetTimer()
 	pullStart := time.Now()
+	time.Sleep(60 * time.Second)
 	log.G(ctx).WithField("benchmark", "Test").WithField("event", "Start").Infof("Start Test")
 	log.G(ctx).WithField("benchmark", "Pull").WithField("event", "Start").Infof("Start Pull Image")
 	image, err := sociContainerdProc.SociRPullImageFromRegistry(ctx, imageRef, indexDigest)


### PR DESCRIPTION
This commit adds 60 secs delay to the benchmark tests

**Issue #, if available:**

**Description of changes:**

**Testing performed:**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
